### PR TITLE
Do not call trim on CompletionItemLabel 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "al-navigator",
-	"version": "0.5.3",
+	"version": "0.5.4",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "al-navigator",
-			"version": "0.5.3",
+			"version": "0.5.4",
 			"license": "MIT",
 			"dependencies": {
 				"-": "^0.0.1",
@@ -23,7 +23,7 @@
 				"@types/glob": "^7.1.1",
 				"@types/mocha": "^5.2.6",
 				"@types/node": "^10.12.21",
-				"@types/vscode": "^1.39.0",
+				"@types/vscode": "^1.83.0",
 				"glob": "^7.1.4",
 				"mocha": "^10.2.0",
 				"tslint": "^5.12.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,9 +94,9 @@
 			"dev": true
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.39.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.39.0.tgz",
-			"integrity": "sha512-rlg0okXDt7NjAyHXbZ2nO1I/VY/8y9w67ltLRrOxXQ46ayvrYZavD4A6zpYrGbs2+ZOEQzcUs+QZOqcVGQIxXQ==",
+			"version": "1.83.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.83.0.tgz",
+			"integrity": "sha512-3mUtHqLAVz9hegut9au4xehuBrzRE3UJiQMpoEHkNl6XHliihO7eATx2BMHs0odsmmrwjJrlixx/Pte6M3ygDQ==",
 			"dev": true
 		},
 		"node_modules/adm-zip": {
@@ -2552,9 +2552,9 @@
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.39.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.39.0.tgz",
-			"integrity": "sha512-rlg0okXDt7NjAyHXbZ2nO1I/VY/8y9w67ltLRrOxXQ46ayvrYZavD4A6zpYrGbs2+ZOEQzcUs+QZOqcVGQIxXQ==",
+			"version": "1.83.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.83.0.tgz",
+			"integrity": "sha512-3mUtHqLAVz9hegut9au4xehuBrzRE3UJiQMpoEHkNl6XHliihO7eATx2BMHs0odsmmrwjJrlixx/Pte6M3ygDQ==",
 			"dev": true
 		},
 		"adm-zip": {

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
 		"@types/glob": "^7.1.1",
 		"@types/mocha": "^5.2.6",
 		"@types/node": "^10.12.21",
-		"@types/vscode": "^1.39.0",
+		"@types/vscode": "^1.83.0",
 		"glob": "^7.1.4",
 		"mocha": "^10.2.0",
 		"tslint": "^5.12.1",

--- a/src/additional/stringFunctions.ts
+++ b/src/additional/stringFunctions.ts
@@ -1,3 +1,5 @@
+import { CompletionItemLabel } from "vscode";
+
 export module StringFunctions {
     export function removeDoubleQuotesFromString(text: string): string {
         return text.replace(/"/g, "");
@@ -15,7 +17,15 @@ export module StringFunctions {
         return (text.includes(" ") || text.includes("+") || text.includes("/") || text.includes("-"));
     }
 
-    export function fromNameText(name: string): string {
+    function isCompletionItemLabel(obj: any): obj is CompletionItemLabel {
+        return typeof obj === 'object' && 'label' in obj && typeof obj.label === 'string';
+    }
+
+    export function fromNameText(name: string | CompletionItemLabel): string {
+        if (isCompletionItemLabel(name)) {
+            name = name.label;
+        }
+
         name = name.trim();
         if ((name.length > 1) && (name.substr(0, 1) === "\"") && (name.substr(name.length - 1, 1) === "\"")) {
             name = name.substr(1, name.length - 2).replace(new RegExp("\"\"", "g"), "\"");

--- a/src/al_code_outline/devToolsExtensionContext.ts
+++ b/src/al_code_outline/devToolsExtensionContext.ts
@@ -92,7 +92,7 @@ export class ALCodeOutlineExtension {
         if (!fileContent) {
             return [];
         }
-        let list: any;
+        let list: vscode.CompletionList | undefined;
         if (objectType === ObjectTypes.table) {
             list = await azALDevTools.alLangProxy.getCompletionForSourceCode(undefined, "", fileContent, 4, 9, 7, 1);
         }


### PR DESCRIPTION
VsCode introduced a union type for the ``label`` property of ``CompletionItem``:
```javascript
label: string | CompletionItemLabel;
```
The code failed when calling ``trim`` on this ``CompletionItemLabel``.
I had to update the version for the ``@types/vscode`` package from version 1.39.0 to 1.83.0, so I could use this new type.

Fixes #112 