### PR TITLE
Changed the case of the array datatype #127

### DIFF
--- a/src/al/alDataTypes.ts
+++ b/src/al/alDataTypes.ts
@@ -1,5 +1,5 @@
 export enum ALDataTypes {
-    none = "none", array = "Array", Action = "Action",
+    none = "none", array = "array", Action = "Action",
     BigInteger = "BigInteger", BigText = "BigText", Boolean = "Boolean", Byte = "Byte",
     Char = "Char", ClientType = "ClientType", Code = "Code", Codeunit = "Codeunit", ControlAddIn = "ControlAddIn",
     DataClassification = "DataClassification", DataScope = "DataScope", Date = "Date", DateFormula = "DateFormula", DateTime = "DateTime", Decimal = "Decimal", DefaultLayout = "DefaultLayout", Dialog = "Dialog", Dictionary = "Dictionary", DotNet = "DotNet", Duration = "Duration",


### PR DESCRIPTION
The Microsoft documentation states that array declarations shold be in the format `AddrArray: array[8] of Text[100];`