### PR TITLE
Fix: resolve linkify-it ReDoS vulnerability (quadratic complexity)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "al-navigator",
-	"version": "0.9.5",
+	"version": "0.9.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "al-navigator",
-			"version": "0.9.5",
+			"version": "0.9.7",
 			"license": "MIT",
 			"dependencies": {
 				"-": "^0.0.1",
@@ -1680,12 +1680,27 @@
 			}
 		},
 		"node_modules/linkify-it": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
-			"integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+			"integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/markdown-it"
+				}
+			],
 			"dependencies": {
-				"uc.micro": "^1.0.1"
+				"uc.micro": "^2.0.0"
 			}
+		},
+		"node_modules/linkify-it/node_modules/uc.micro": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+			"integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="
 		},
 		"node_modules/listenercount": {
 			"version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -237,6 +237,9 @@
 	"extensionDependencies": [
 		"andrzejzwierzchowski.al-code-outline"
 	],
+	"overrides": {
+		"linkify-it": "^5.0.1"
+	},
 	"dependencies": {
 		"-": "^0.0.1",
 		"@vscode/extension-telemetry": "^0.9.0",


### PR DESCRIPTION
## Summary
Fixes the reported `linkify-it` quadratic algorithmic complexity (ReDoS) vulnerability.

## Details
- Vulnerable package `linkify-it@3.0.3` was pulled in transitively via `vsce@2.15.0 → markdown-it@12.3.2 → linkify-it@3.0.3` (devDependency, used only for packaging).
- Added an `overrides` entry in `package.json` to force `linkify-it` to `^5.0.1` (patched version) across the dependency tree.
- Regenerated `package-lock.json` via `npm install`.

## Verification
- `npm ls linkify-it` confirms `linkify-it@5.0.2 overridden`.
- `npm run compile` succeeds with no errors.
