### PR TITLE
Fix: Update fast-uri to patch SSRF/host confusion vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2246,9 +2246,9 @@
 			}
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-			"integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+			"integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
 			"dev": true,
 			"funding": [
 				{


### PR DESCRIPTION
## Summary
Updates the transitive `fast-uri` dependency (via `@vscode/vsce` → `@secretlint/config-loader` → `ajv`) from `3.1.5` to `3.1.7`, resolving the two Dependabot alerts:

- **High**: fast-uri vulnerable to host confusion via skipped IDN canonicalization on scheme-relative references (GHSA-5jgf-p345-68v8)
- **High**: fast-uri vulnerable to server-side request forgery via repeated hostname percent-decoding (GHSA-fph4-wmhf-6fwf)

Both are fixed in `fast-uri@3.1.6`+; `3.1.7` was installed via `npm update fast-uri`, which also happens to include additional hardening from two more advisories published after `3.1.6`.

## Changes
- `package-lock.json`: `fast-uri` bumped `3.1.5` → `3.1.7`

`package.json` is unaffected since `fast-uri` is not a direct dependency.

## Testing
- `npm ls fast-uri` confirms resolved version `3.1.7`
- No source code changes; dev-only transitive dependency